### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Prepare docker release
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ikkerens/fake_haproxy
           username: ikkerens

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Test code correctness
       run: cargo clippy --all -- -D warnings
     - name: Build docker
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: docker.pkg.github.com/ikkerens/fake_haproxy/fake_haproxy
         username: ikkerens


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore